### PR TITLE
Prevent numbered sections

### DIFF
--- a/_extensions/trb/_extension.yml
+++ b/_extensions/trb/_extension.yml
@@ -16,6 +16,7 @@ contributes:
       include-in-header: header.tex
       documentclass: article
       classoption: 12pt
+      number-sections: false
       papersize: letter
       template-partials:
         - partials/before-body.tex


### PR DESCRIPTION
In porting my paper over for this format, I had missing number [treated as zero] errors in LaTeX resulting from missing numbers in the titlesec package. Forcing sections to not be numbered resolved this issue; maybe should turn back on when the titlesec error can be be identified